### PR TITLE
Bid object onBidWon notice is having array params

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -99,7 +99,7 @@ export const spec = {
 }
 
 function buildTrackingParams(data, info, value) {
-  const accountId = data.params.accountId;
+  const accountId = data.params.accountId || data.params[0].accountId;
   return {
     pid: accountId === undefined ? data.ad.match(/account: \“([a-f\d]{24})\“/)[1] : accountId,
     nid: data.params.networkId,


### PR DESCRIPTION
Don't know why params are in an array in that bid object. Make it work for both if it is fixed later

## Type of change
- [x] Bugfix
 
## Description of change
Our tracker was not working as the bid on bidWon and bidTimeout notice is having a "params" item as an array. Just get the first for that part of code 
