### PR TITLE
Keywords have to be an array of string

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -40,6 +40,19 @@ export const spec = {
     const pageUrl = getPageUrl(bidderRequest.refererInfo, window);
     const gdpr = bidderRequest.gdprConsent;
     const firstSlot = slots[0];
+    const kwdsFromRequest = bidderRequest.ortb2?.site?.keywords;
+    let keywords = [];
+    if (kwdsFromRequest) {
+      if (isArray(kwdsFromRequest)) {
+        keywords = kwdsFromRequest;
+      } else {
+        if (kwdsFromRequest.indexOf(",") != -1) {
+          keywords = kwdsFromRequest.split(",");
+        } else {
+          keywords.push(kwdsFromRequest);
+        }
+      }
+    }
     const payloadObject = {
       at: new Date().toString(),
       nid: firstSlot.nid,
@@ -47,12 +60,13 @@ export const spec = {
       pid: firstSlot.pid,
       url: pageUrl,
       lang: (window.navigator.language || window.navigator.languages[0]),
-      kwds: bidderRequest.ortb2?.site?.keywords || [],
+      kwds: keywords,
       dbg: false,
       slts: slots,
       is_amp: deepAccess(bidderRequest, 'referrerInfo.isAmp'),
       tc_string: (gdpr && gdpr.gdprApplies) ? gdpr.consentString : null,
     };
+
     const payloadString = JSON.stringify(payloadObject);
     return {
       method: 'POST',

--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, isArray, logWarn, triggerPixel, buildUrl, logInfo, getValue, getBidIdParameter } from '../src/utils.js';
+import { deepAccess, isArray, logWarn, triggerPixel, buildUrl, logInfo, getValue, getBidIdParameter, isStr } from '../src/utils.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
@@ -45,7 +45,7 @@ export const spec = {
     if (kwdsFromRequest) {
       if (isArray(kwdsFromRequest)) {
         keywords = kwdsFromRequest;
-      } else {
+      } else if (isStr(kwdsFromRequest)) {
         if (kwdsFromRequest.indexOf(",") != -1) {
           keywords = kwdsFromRequest.split(",");
         } else {

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -216,4 +216,43 @@ describe('BeOp Bid Adapter tests', () => {
       expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.include('pid=5a8af500c9e77c00017e4cad');
     });
   });
+
+  describe("Ensure keywords is always array of string", function () {
+    let bidRequests = [];
+    bidRequests.push(validBid);
+
+    it("should work with keywords as an array", function () {
+      config.setConfig({
+        currency: { adServerCurrency: "USD" },
+        ortb: { site: { keywords: ["a", "b"] } },
+      });
+      const request = spec.buildRequests(bidRequests, {});
+      const payload = JSON.parse(request.data);
+      const url = request.url;
+      expect(payload.kwd).to.exist;
+      expect(payload.kwd).to.equal(["a", "b"]);
+    });
+
+    it("should work with keywords as a string", function () {
+      config.setConfig({
+        currency: { adServerCurrency: "USD" },
+        ortb: { site: { keywords: "list of keywords" } },
+      });
+      const request = spec.buildRequests(bidRequests, {});
+      const payload = JSON.parse(request.data);
+      const url = request.url;
+      expect(payload.kwd).to.exist;
+      expect(payload.kwd).to.equal(["list of keywords"]);
+    });
+
+    it("should work with keywords as a string containing a comma", function () {
+      config.setConfig({
+        currency: { adServerCurrency: "USD" },
+        ortb: { site: { keywords: "list, of, keywords" } },
+      });
+      const request = spec.buildRequests(bidRequests, {});
+      const payload = JSON.parse(request.data);
+      const url = request.url;
+      expect(payload.kwd).to.exist;
+      expect(payload.kwd).to.equal(["list", "of", "keywords"]);
 });


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

Keywords on publisher definition are sometimes just passed as a String, and not an array of String. That fix is always resolving keywords as an array for our bid adapter

N.B. : The file has been reformatted in that PR, let me know if this is problematic for you