### PR TITLE
Remove the notion of 'auction_id' as we do not do anything with it

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -129,8 +129,6 @@ function buildTrackingParams(data, info, value) {
     nptnid: params.networkPartnerId,
     bid: data.bidId || data.requestId,
     sl_n: data.adUnitCode,
-    // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
-    aid: data.auctionId,
     se_ca: 'bid',
     se_ac: info,
     se_va: value,
@@ -158,8 +156,6 @@ function beOpRequestSlotsMaker(bid) {
     bid: getBidIdParameter('bidId', bid),
     brid: getBidIdParameter('bidderRequestId', bid),
     name: getBidIdParameter('adUnitCode', bid),
-    // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
-    aid: getBidIdParameter('auctionId', bid),
     tid: bid.ortb2Imp?.ext?.tid || '',
     brc: getBidIdParameter('bidRequestsCount', bid),
     bdrc: getBidIdParameter('bidderRequestCount', bid),


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Remove the notion of auction_id in beOpBidAdapter

## Other information
FIXES https://github.com/prebid/Prebid.js/issues/9781
